### PR TITLE
errorfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This tutorial environment is not intended to demonstrate a production deployment
 
     1. `ansible-playbook`
 
+    2. `python3`
+
+    3. `pip3 install pyyaml kubernetes openshift`
+
     2. `oc` - [logged in as a cluster administrator](https://docs.openshift.com/container-platform/4.12/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 
     3.  Entitlement key from the [IBM Container software library](https://myibm.ibm.com/products-services/containerlibrary).

--- a/install/eventstreams/templates/07-kafkaconnect.yaml
+++ b/install/eventstreams/templates/07-kafkaconnect.yaml
@@ -42,7 +42,7 @@ spec:
       metadata:
         annotations:
           cloudpakId: c8b82d189e7545f0892db9ef2731b90d
-          productVersion: 11.2.1
+          productVersion: 11.2.0
           productID: 2a79e49111f44ec3acd89608e56138f5
           cloudpakName: IBM Cloud Pak for Integration
           productChargedContainers: kafka-connect-cluster-connect


### PR DESCRIPTION
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"admission webhook \\\\\"eventstreams.ibm.com.rejectinvalidkafkaconnectmetering\\\\\" denied the request: KafkaConnect spec is missing metering annotations. Edit the following paths and provide the appropriate values: spec.template.pod.metadata.annotations.productVersion=11.2.0.\",\"reason\":\"MissingMeteringAnnotations\",\"code\":400}\\n'", "reason": "Bad Request"}