### PR TITLE
fix: add missing pip dependency

### DIFF
--- a/install/common/prerequisites.yaml
+++ b/install/common/prerequisites.yaml
@@ -4,3 +4,4 @@
       - openshift
       - pyyaml
       - kubernetes
+      - jmespath


### PR DESCRIPTION
A user reported this error when running the ansible playbook

```
TASK [Wait for the catalog source to be ready] **********************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'pod_list|json_query('resources[*].status.conditions[1].status')|unique == [\"True\"]' failed. The error was: You need to install \"jmespath\" prior to running json_query filter"}
```

Adding this dependency explicitly should avoid this error in future.