### PR TITLE
docs: update storage class recommendations for ROKS installs

### DIFF
--- a/INSTALL-OPTIONS.md
+++ b/INSTALL-OPTIONS.md
@@ -44,9 +44,9 @@ ansible-playbook \
     -e license_accept=true \
     -e ibm_entitlement_key=YOUR-ENTITLEMENT-KEY \
     -e install_certmgr=true \
-    -e eventstreams_storage_class=ibmc-file-gold-gid \
-    -e eventendpointmanagement_storage_class=ibmc-file-bronze-gid \
-    -e eventprocessing_storage_class=ibmc-file-bronze-gid \
+    -e eventstreams_storage_class=ibmc-block-gold \
+    -e eventendpointmanagement_storage_class=ibmc-block-bronze \
+    -e eventprocessing_storage_class=ibmc-block-bronze \
     -e eventautomation_namespace=event-automation \
     install/event-automation.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ ansible-playbook \
     -e license_accept=true \
     -e ibm_entitlement_key=YOUR-KEY-HERE \
     -e install_certmgr=true \
-    -e eventstreams_storage_class=ibmc-file-gold-gid \
-    -e eventendpointmanagement_storage_class=ibmc-file-bronze-gid \
-    -e eventprocessing_storage_class=ibmc-file-bronze-gid \
+    -e eventstreams_storage_class=ibmc-block-gold \
+    -e eventendpointmanagement_storage_class=ibmc-block-bronze \
+    -e eventprocessing_storage_class=ibmc-block-bronze \
     -e eventautomation_namespace=event-automation \
     install/event-automation.yaml
 ```


### PR DESCRIPTION
Event Streams favours block storage, so switching the
 recommendation to use that instead.

EEM and EP are happy with file storage, however the file storage classes (e.g. ibmc-file-bronze-gid, ibmc-file-silver-gid, etc.) are not available in multizone clusters. We could leave the file storage class in, and have a separate example for multi-zone clusters, however I feel like that is unnecessarily complex - and this example will work on both single-zone and multi-zone ROKS clusters.