### PR TITLE
fix: correct the scope of the Apicurio jars in the Connect runtime

### DIFF
--- a/install/eventstreams/templates/07-kafkaconnect.yaml
+++ b/install/eventstreams/templates/07-kafkaconnect.yaml
@@ -60,17 +60,12 @@ spec:
   build:
     output:
       type: docker
-      image: image-registry.openshift-image-registry.svc:5000/{{ eventautomation_namespace }}/event-automation-demo:0.0.6
+      image: image-registry.openshift-image-registry.svc:5000/{{ eventautomation_namespace }}/event-automation-demo:0.0.7
     plugins:
       - name: datagen
         artifacts:
           - type: jar
             url: https://github.com/IBM/kafka-connect-loosehangerjeans-source/releases/download/0.0.6/kafka-connect-loosehangerjeans-source-0.0.6-jar-with-dependencies.jar
-      - name: mq-source
-        artifacts:
-          - type: jar
-            url: https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v1.3.4/kafka-connect-mq-source-1.3.4-jar-with-dependencies.jar
-      - artifacts:
           - artifact: apicurio-registry-serdes-avro-serde
             group: io.apicurio
             type: maven
@@ -79,4 +74,7 @@ spec:
             group: io.apicurio
             type: maven
             version: 2.5.10.Final
-        name: apicurio
+      - name: mq-source
+        artifacts:
+          - type: jar
+            url: https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v1.3.4/kafka-connect-mq-source-1.3.4-jar-with-dependencies.jar


### PR DESCRIPTION
Apicurio jars were in the Connect build as a plugin in their own right, despite only being used by the loosehangerjeans-source Connector.

This was risky, as it meant that if another Connector is added to the Connect runtime that also happens to include a different version of the io.apicurio.registry.utils.converter.AvroConverter class, there is a chance that this will be used instead.

This commit modifies the Kaniko build config to more explicitly scope the Apicurio classes as being used by the loosehangerjeans Connector. This means that if additional Connectors are added to the runtime that also have their version of AvroConverter, it will not impact the datagen connector.