### PR TITLE
chore: Update loosehanger source version

### DIFF
--- a/install/eventstreams/templates/07-kafkaconnect.yaml
+++ b/install/eventstreams/templates/07-kafkaconnect.yaml
@@ -65,7 +65,7 @@ spec:
       - name: datagen
         artifacts:
           - type: jar
-            url: https://github.com/IBM/kafka-connect-loosehangerjeans-source/releases/download/0.1.2/kafka-connect-loosehangerjeans-source-0.1.2-jar-with-dependencies.jar
+            url: https://github.com/IBM/kafka-connect-loosehangerjeans-source/releases/download/0.1.3/kafka-connect-loosehangerjeans-source-0.1.3-jar-with-dependencies.jar
           - artifact: apicurio-registry-serdes-avro-serde
             group: io.apicurio
             type: maven


### PR DESCRIPTION
This bumps up the version of loosehangerjeans kafka source connector source version to `0.1.3` from `0.1.2`

PS: only merge once the PR in loosehanger is merged. Link to PR, https://github.com/IBM/kafka-connect-loosehangerjeans-source/pull/9